### PR TITLE
Fix creation/permissions for /messages/sns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ COPY Gemfile /Gemfile
 RUN bundle install
 
 RUN useradd -u 1000 -M docker \
-  && mkdir -p /sns \
-  && chown docker /sns
+  && mkdir -p /messages/sns \
+  && chown docker /messages/sns
 USER docker
 
 VOLUME /messages/sns


### PR DESCRIPTION
#1 breaks permissions on build, leading the app to crash on use; this fixes that oversight.
