### PR TITLE
Add awscli to be used in dokku-fakesns

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 # Note: We use a forked copy of fake_sns because the original author does not
 # seem too interested fixing bugs.  Specifically, we are interested in binding
 # our webserver the any address.  See https://github.com/yourkarma/fake_sns/pull/5
+gem 'awscli'
 gem 'thin'
 gem 'fake_sns', git: 'https://github.com/feathj/fake_sns.git'


### PR DESCRIPTION
- Add awscli, so we can use docker exec to modify SNS queues.
